### PR TITLE
Fix: Getting unusual heights when drawing and editing polygons

### DIFF
--- a/modules/plot/draw/DrawPolygon.js
+++ b/modules/plot/draw/DrawPolygon.js
@@ -34,7 +34,9 @@ class DrawPolygon extends Draw {
         ...this._style,
         hierarchy: new Cesium.CallbackProperty(() => {
           if (this._positions.length > 2) {
-            return new Cesium.PolygonHierarchy(this._positions)
+            return new Cesium.PolygonHierarchy(
+              this._positions.map(item => item.clone())
+            )
           } else {
             return null
           }

--- a/modules/plot/edit/EditPolygon.js
+++ b/modules/plot/edit/EditPolygon.js
@@ -21,7 +21,9 @@ class EditPolygon extends Edit {
   _mountedHook() {
     this._delegate.polygon.hierarchy = new Cesium.CallbackProperty(time => {
       if (this._positions.length > 2) {
-        return new Cesium.PolygonHierarchy(this._positions)
+        return new Cesium.PolygonHierarchy(
+          this._positions.map(item => item.clone())
+        )
       } else {
         return null
       }


### PR DESCRIPTION
the problem that the Cesium.PolygonHierarchy class will modify the data of positions when drawing and editing polygons, resulting in abnormal height after stopdHook conversion.