### PR TITLE
fix: 谷歌底图路径已失效，仿照火星科技修改谷歌底图路径指向

### DIFF
--- a/src/modules/imagery/provider/GoogleImageryProvider.js
+++ b/src/modules/imagery/provider/GoogleImageryProvider.js
@@ -5,10 +5,23 @@
 import { Cesium } from '../../../namespace'
 import ImageryType from '../ImageryType'
 
+/**
+ *
+ * 地址：https://gac-geo.googlecnapps.cn/maps/vt?lyrs=s&x={x}&y={y}&z={z}
+ * 底图类型：
+ *  m 标准路线图 lyrs=m
+ *  r 某种改变的路线图（路线不明显） lyrs=r
+ *  s 影像层（卫星图） lyrs=s
+ *  y 带标签的卫星图 lyrs=y
+ *  h 标签层（路名、地名等） lyrs=h
+ *  t 地形图 lyrs=t
+ *  p 带标签的地形图 lyrs=p
+ *
+ */
 const TILE_URL = {
-  img: '//mt{s}.google.cn/vt/lyrs=s&hl=zh-CN&x={x}&y={y}&z={z}&s=Gali',
-  elec: '//mt{s}.google.cn/vt/lyrs=m@207000000&hl=zh-CN&gl=CN&src=app&x={x}&y={y}&z={z}&s=Galile',
-  ter: '//mt{s}.google.cn/vt/lyrs=t@131,r@227000000&hl=zh-CN&gl=cn&x={x}&y={y}&z={z}&s=Galile',
+  img: 'https://gac-geo.googlecnapps.cn/maps/vt?lyrs=s&x={x}&y={y}&z={z}',
+  elec: 'https://gac-geo.googlecnapps.cn/maps/vt?lyrs=m&x={x}&y={y}&z={z}',
+  ter: 'https://gac-geo.googlecnapps.cn/maps/vt?lyrs=t@131,r&x={x}&y={y}&z={z}',
 }
 
 class GoogleImageryProvider extends Cesium.UrlTemplateImageryProvider {


### PR DESCRIPTION
当前项目谷歌底图路径已失效，仿照火星科技修改谷歌底图路径指向，参考：
[谷歌影像如何正确使用](https://zhuanlan.zhihu.com/p/630607163)
```diff
- img: '//mt{s}.google.cn/vt/lyrs=s&hl=zh-CN&x={x}&y={y}&z={z}&s=Gali',
- elec: '//mt{s}.google.cn/vt/lyrs=m@207000000&hl=zh-CN&gl=CN&src=app&x={x}&y={y}&z={z}&s=Galile',
- ter: '//mt{s}.google.cn/vt/lyrs=t@131,r@227000000&hl=zh-CN&gl=cn&x={x}&y={y}&z={z}&s=Galile',

+ img: 'https://gac-geo.googlecnapps.cn/maps/vt?lyrs=s&x={x}&y={y}&z={z}',
+ elec: 'https://gac-geo.googlecnapps.cn/maps/vt?lyrs=m&x={x}&y={y}&z={z}',
+ ter: 'https://gac-geo.googlecnapps.cn/maps/vt?lyrs=t@131,r&x={x}&y={y}&z={z}',
```