### PR TITLE
fix: 修复 center.js 文件的 center 方法高程计算错误的BUG

### DIFF
--- a/src/modules/math/center.js
+++ b/src/modules/math/center.js
@@ -8,10 +8,15 @@ import Position from '../position/Position'
 
 export default function center(positions) {
   if (positions && Array.isArray(positions)) {
+    let heightMax = 0 // 位置最高的点的高度
+    positions.forEach(({ alt }) => (heightMax = Math.max(heightMax, alt)))
+
     let boundingSphere = Cesium.BoundingSphere.fromPoints(
       Transform.transformWGS84ArrayToCartesianArray(positions)
     )
-    return Transform.transformCartesianToWGS84(boundingSphere.center)
+    const position = Transform.transformCartesianToWGS84(boundingSphere.center)
+    position.alt = heightMax
+    return position
   }
 
   return new Position()


### PR DESCRIPTION
文件`center.js` 的`center` 方法计算出来的中心点高程属性是错误的；该方法只是计算在三维空间中的中心位置，但是地球是圆形的，并不完全符合
当数据的范围比较大（例如大于一个市）时就会很明显
测试案例（该案例中的平面没有高程坐标，理论上中心点的高程坐标也应该是 0 ）：
```html
<!DOCTYPE html>
<html lang="en">

<head>
  <meta charset="utf-8">
  <meta name="viewport" content="width=device-width,initial-scale=1.0">
  <title>dc-example</title>
  <script src='/libs/dc-sdk/dc.min.js'></script>
  <link href='/libs/dc-sdk/dc.min.css' type='text/css' rel='stylesheet'>
  <link href='../index.css' type='text/css' rel='stylesheet'>
</head>

<body>

  <div id="viewer-container" class="viewer-container"></div>
  <script>
    let viewer = undefined

    function initViewer() {
      viewer = new DC.Viewer('viewer-container')
      let baseLayer = DC.ImageryLayerFactory.createImageryLayer(DC.ImageryType.AMAP)
      viewer.addBaseLayer(baseLayer)
      let geoJson = new DC.GeoJsonLayer(undefined, 'http://data.mars3d.cn/file/geojson/areas/340000_full.json')

      const layer = geoJson.toVectorLayer()
      viewer.addLayer(layer)
      viewer.flyTo(layer)

      geoJson.delegate.then(() => {
        layer.eachOverlay((lyr) => {
          console.log("计算后中心点的高度为 = ", lyr.center.alt);
        })
      })


    }

    DC.ready({
      baseUrl: '../libs/dc-sdk/resources/'
    }).then(initViewer)
  </script>
```