### PR TITLE
fix: Parse.parsePosition 增加转换类型支持

### DIFF
--- a/src/modules/parse/Parse.js
+++ b/src/modules/parse/Parse.js
@@ -2,6 +2,8 @@
  * @Author : Caven Chen
  */
 import Position from '../position/Position'
+import { Cesium } from '../../namespace'
+import { Transform } from '../transform'
 
 class Parse {
   /**
@@ -26,6 +28,10 @@ class Parse {
       result = Position.fromObject(position)
     } else if (Object(position) instanceof Position) {
       result = position
+    } else if (Object(position) instanceof Cesium.Cartesian3) {
+      result = Transform.transformCartesianToWGS84(position)
+    } else if (Object(position) instanceof Cesium.Cartographic) {
+      result = Transform.transformCartographicToWGS84(position)
     }
     return result
   }

--- a/src/modules/transform/Transform.js
+++ b/src/modules/transform/Transform.js
@@ -27,6 +27,22 @@ class Transform {
   }
 
   /**
+   * Transforms Cartographic To WGS84
+   * @param cartographic
+   * @returns {Position}
+   */
+  static transformCartographicToWGS84(cartographic) {
+    if (cartographic) {
+      return new Position(
+        Cesium.Math.toDegrees(cartographic?.longitude || 0),
+        Cesium.Math.toDegrees(cartographic?.latitude || 0),
+        cartographic.height || 0
+      )
+    }
+    return new Position(0, 0)
+  }
+
+  /**
    * Transforms WGS84 To Cartesian
    * @param position
    * @returns {Cartesian3}


### PR DESCRIPTION
增加支持 `Cesium.Cartesian3` 和 `Cesium.Cartographic` 类型的数据直接转换为`Position` 格式
方便以下类似情况的调用
```js
// 情况1
const item = new Cesium.Cartesian3()
const point = new DC.Point(item)
// 情况2
const item = new Cesium.Cartographic()
const point = new DC.Point(item)
```


