### PR TITLE
fix: 修复 vue 使用 proxy 代理时找不到对象的BUG

### DIFF
--- a/src/modules/widget/type/Compass.js
+++ b/src/modules/widget/type/Compass.js
@@ -38,9 +38,11 @@ class Compass extends Widget {
    * @private
    */
   _installHook() {
+    const self = this
     Object.defineProperty(this._viewer, 'compass', {
-      value: this,
-      writable: false,
+      get() {
+        return self
+      },
     })
     this._wrapper.onmousedown = (e) => {
       this._handleMouseDown(e)

--- a/src/modules/widget/type/ContextMenu.js
+++ b/src/modules/widget/type/ContextMenu.js
@@ -59,9 +59,11 @@ class ContextMenu extends Widget {
    * @private
    */
   _installHook() {
+    const self = this
     Object.defineProperty(this._viewer, 'contextMenu', {
-      value: this,
-      writable: false,
+      get() {
+        return self
+      },
     })
     this._handler = new Cesium.ScreenSpaceEventHandler(this._viewer.canvas)
   }

--- a/src/modules/widget/type/DistanceLegend.js
+++ b/src/modules/widget/type/DistanceLegend.js
@@ -41,9 +41,11 @@ class DistanceLegend extends Widget {
    * @private
    */
   _installHook() {
+    const self = this
     Object.defineProperty(this._viewer, 'distanceLegend', {
-      value: this,
-      writable: false,
+      get() {
+        return self
+      },
     })
   }
 

--- a/src/modules/widget/type/HawkeyeMap.js
+++ b/src/modules/widget/type/HawkeyeMap.js
@@ -64,9 +64,11 @@ class HawkeyeMap extends Widget {
    * @private
    */
   _installHook() {
+    const self = this
     Object.defineProperty(this._viewer, 'hawkeyeMap', {
-      value: this,
-      writable: false,
+      get() {
+        return self
+      },
     })
     this._viewer.camera.percentageChanged = 0.01
   }

--- a/src/modules/widget/type/LoadingMask.js
+++ b/src/modules/widget/type/LoadingMask.js
@@ -22,9 +22,11 @@ class LoadingMask extends Widget {
    * @private
    */
   _installHook() {
+    const self = this
     Object.defineProperty(this._viewer, 'loadingMask', {
-      value: this,
-      writable: false,
+      get() {
+        return self
+      },
     })
   }
 

--- a/src/modules/widget/type/LocationBar.js
+++ b/src/modules/widget/type/LocationBar.js
@@ -34,9 +34,11 @@ class LocationBar extends Widget {
    * @private
    */
   _installHook() {
+    const self = this
     Object.defineProperty(this._viewer, 'locationBar', {
-      value: this,
-      writable: false,
+      get() {
+        return self
+      },
     })
   }
 

--- a/src/modules/widget/type/MapSplit.js
+++ b/src/modules/widget/type/MapSplit.js
@@ -26,9 +26,11 @@ class MapSplit extends Widget {
    * @private
    */
   _installHook() {
+    const self = this
     Object.defineProperty(this._viewer, 'mapSplit', {
-      value: this,
-      writable: false,
+      get() {
+        return self
+      },
     })
   }
 

--- a/src/modules/widget/type/MapSwitch.js
+++ b/src/modules/widget/type/MapSwitch.js
@@ -34,12 +34,14 @@ class MapSwitch extends Widget {
    * @private
    */
   _installHook() {
+    const self = this
     Object.defineProperty(this._viewer, 'mapSwitch', {
-      value: this,
-      writable: false,
+      get() {
+        return self
+      },
     })
     this.enable = true
-    let self = this
+    // let self = this
     this._wrapper.onmouseover = () => {
       let width = 80
       let rightMargin = 5

--- a/src/modules/widget/type/Popup.js
+++ b/src/modules/widget/type/Popup.js
@@ -65,9 +65,11 @@ class Popup extends Widget {
   _installHook() {
     this.enable = true
     this._bindEvent()
+    const self = this
     Object.defineProperty(this._viewer, 'popup', {
-      value: this,
-      writable: false,
+      get() {
+        return self
+      },
     })
   }
 

--- a/src/modules/widget/type/SceneSplit.js
+++ b/src/modules/widget/type/SceneSplit.js
@@ -27,9 +27,11 @@ class SceneSplit extends Widget {
    * @private
    */
   _installHook() {
+    const self = this
     Object.defineProperty(this._viewer, 'sceneSplit', {
-      value: this,
-      writable: false,
+      get() {
+        return self
+      },
     })
   }
 

--- a/src/modules/widget/type/TilesetSplit.js
+++ b/src/modules/widget/type/TilesetSplit.js
@@ -26,9 +26,11 @@ class TilesetSplit extends Widget {
    * @private
    */
   _installHook() {
+    const self = this
     Object.defineProperty(this._viewer, 'tilesetSplit', {
-      value: this,
-      writable: false,
+      get() {
+        return self
+      },
     })
   }
 

--- a/src/modules/widget/type/Tooltip.js
+++ b/src/modules/widget/type/Tooltip.js
@@ -23,9 +23,11 @@ class Tooltip extends Widget {
    * @private
    */
   _installHook() {
+    const self = this
     Object.defineProperty(this._viewer, 'tooltip', {
-      value: this,
-      writable: false,
+      get() {
+        return self
+      },
     })
   }
 

--- a/src/modules/widget/type/ZoomController.js
+++ b/src/modules/widget/type/ZoomController.js
@@ -154,9 +154,11 @@ class ZoomController extends Widget {
    * @private
    */
   _installHook() {
+    const self = this
     Object.defineProperty(this._viewer, 'zoomController', {
-      value: this,
-      writable: false,
+      get() {
+        return self
+      },
     })
   }
 


### PR DESCRIPTION
异常的示例代码
```js
import { readonly } from "vue"

const map = new DC.Viewer('viewer-container')
const rMap = readonly(map)
console.log(rMap.popup)
```
当数据被 `vue` 使用 `proxy` 代理 后会报如下错误
```
TypeError: 'get' on proxy: property 'popup' is a read-only and non-configurable data property on the proxy target but the proxy did not return its actual value (expected '#<As>' but got '#<As>')
```
![image](https://github.com/dvgis/dc-sdk/assets/39983519/bb17b94e-e6c7-4db4-914c-6113c9f5d85e)
国内使用 `vue` 的还是比较多的，难免会遇到错误

