### PR TITLE
fix: 优化 Parse.parsePositions 调用

### DIFF
--- a/examples/list.js
+++ b/examples/list.js
@@ -681,4 +681,4 @@ const EXAMPLE_LIST = [
       },
     ],
   },
-]``
+]

--- a/src/modules/parse/Parse.js
+++ b/src/modules/parse/Parse.js
@@ -49,19 +49,20 @@ class Parse {
       positions = positions.split(';').filter((item) => !!item)
     }
     return positions.map((item) => {
-      if (typeof item === 'string') {
-        return Position.fromString(item)
-      } else if (Array.isArray(item)) {
-        return Position.fromArray(item)
-      } else if (
-        !(Object(item) instanceof Position) &&
-        Object(item).hasOwnProperty('lng') &&
-        Object(item).hasOwnProperty('lat')
-      ) {
-        return Position.fromObject(item)
-      } else if (Object(item) instanceof Position) {
-        return item
-      }
+      // if (typeof item === 'string') {
+      //   return Position.fromString(item)
+      // } else if (Array.isArray(item)) {
+      //   return Position.fromArray(item)
+      // } else if (
+      //   !(Object(item) instanceof Position) &&
+      //   Object(item).hasOwnProperty('lng') &&
+      //   Object(item).hasOwnProperty('lat')
+      // ) {
+      //   return Position.fromObject(item)
+      // } else if (Object(item) instanceof Position) {
+      //   return item
+      // }
+      return this.parsePosition(item)
     })
   }
 


### PR DESCRIPTION
`Parse.parsePositions` 的实现在内部方法 `ParseparsePosition` 已经实现，直接调用更合理