### PR TITLE
fix: Cesium.Rectangle.center 参数错误

### DIFF
--- a/src/modules/overlay/vector/Rect.js
+++ b/src/modules/overlay/vector/Rect.js
@@ -45,11 +45,9 @@ class Rect extends Overlay {
    * @returns {Rect}
    */
   setLabel(text, textStyle) {
+    const rectangle = this._delegate.rectangle.coordinates.getValue()
     this._delegate.position = Cesium.Cartographic.toCartesian(
-      Cesium.Rectangle.center(
-        this._delegate.rectangle,
-        new Cesium.Cartographic()
-      )
+      Cesium.Rectangle.center(rectangle, new Cesium.Cartographic())
     )
     this._delegate.label = {
       ...textStyle,


### PR DESCRIPTION
如图，方法 `Cesium.Rectangle.center(rectangle, result)`，第一个参数需要`Cesium.Rectangle`类型
![image](https://github.com/dvgis/dc-sdk/assets/39983519/196011ab-5216-462c-bd72-fc9a4a642f02)
未修改之前`this._delegate.rectangle`是`Cesium.RectangleGraphics`类型



