### PR TITLE
fix: Plane 和 Box 属性设置错误

### DIFF
--- a/src/modules/overlay/vector/Box.js
+++ b/src/modules/overlay/vector/Box.js
@@ -57,8 +57,10 @@ class Box extends Overlay {
   }
 
   set length(length) {
+    const dimensions = this._delegate.box.dimensions.getValue()
     this._length = length || 0
-    this._delegate.box.dimensions.x = +this._length
+    dimensions.x = +this._length
+    this._delegate.box.dimensions.setValue(dimensions)
   }
 
   get length() {
@@ -66,8 +68,10 @@ class Box extends Overlay {
   }
 
   set width(width) {
+    const dimensions = this._delegate.box.dimensions.getValue()
     this._width = width || 0
-    this._delegate.box.dimensions.y = +this._width
+    dimensions.y = +this._width
+    this._delegate.box.dimensions.setValue(dimensions)
   }
 
   get width() {
@@ -75,8 +79,10 @@ class Box extends Overlay {
   }
 
   set height(height) {
+    const dimensions = this._delegate.box.dimensions.getValue()
     this._height = height || 0
-    this._delegate.box.dimensions.z = +this._height
+    dimensions.z = +this._height
+    this._delegate.box.dimensions.setValue(dimensions)
   }
 
   get height() {

--- a/src/modules/overlay/vector/Plane.js
+++ b/src/modules/overlay/vector/Plane.js
@@ -13,8 +13,8 @@ class Plane extends Overlay {
   constructor(position, width, height, plane = {}) {
     super()
     this._position = Parse.parsePosition(position)
-    this._width = +width || 0
-    this._height = +height || 0
+    this._width = +width || 100
+    this._height = +height || 100
     if (plane.normal && typeof plane.normal === 'string') {
       let n = String(plane.normal).toLocaleUpperCase()
       plane.normal =
@@ -64,8 +64,9 @@ class Plane extends Overlay {
   }
 
   set width(width) {
+    const dimensions = this._delegate.plane.dimensions.getValue()
     this._width = +width || 0
-    this._delegate.plan.dimensions.x = this._width
+    dimensions.x = this._width
   }
 
   get width() {
@@ -73,8 +74,9 @@ class Plane extends Overlay {
   }
 
   set height(height) {
+    const dimensions = this._delegate.plane.dimensions.getValue()
     this._height = +height || 0
-    this._delegate.plan.dimensions.y = this._height
+    dimensions.y = this._height
   }
 
   get height() {
@@ -82,8 +84,9 @@ class Plane extends Overlay {
   }
 
   set distance(distance) {
+    const plane = this.entityGraphic.plane.getValue()
     this._distance = distance
-    this._delegate.plane.plane.distance = distance
+    plane.distance = distance
   }
 
   get distance() {


### PR DESCRIPTION
修改类 `Box` 的 `length`、`width`、`height` 属性设置，原先直接设置是不行的
修改类 `Plane` 的 `width`、`height`、`distance` 属性设置，原先直接设置是不行的
修改类 `Plane` 的 `width`、`height` 属性的默认值为 `100`，为 `0` 的话无法生成 `plane` ,且 `cesium` 会报错