### PR TITLE
fix: new TilesetEvent 缺少参数

### DIFF
--- a/src/modules/overlay/model/Tileset.js
+++ b/src/modules/overlay/model/Tileset.js
@@ -12,7 +12,7 @@ class Tileset extends Overlay {
   constructor(url, options = {}) {
     super()
     this._delegate = Cesium.Cesium3DTileset.fromUrl(url, options)
-    this._tilesetEvent = new TilesetEvent()
+    this._tilesetEvent = new TilesetEvent(this._delegate)
     this._tileVisibleCallback = undefined
     this._properties = undefined
     this._state = State.INITIALIZED


### PR DESCRIPTION
`TilesetEvent` 的构造函数如下， 类 `Tileset` 调用时缺少参数
```js
class TilesetEvent extends Event {
  constructor(tileset) {
    super(TileSetEventType)
    this._tileset = tileset
  }
```